### PR TITLE
Fix build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-
 language: objective-c
+
+before_install:
+- gem install cocoapods
 
 script:
 - pod lib lint


### PR DESCRIPTION
Current Travis CI build failure should be fixed by simply adding `gem install cocoapods` in Travis config.

Hope this helps. :+1: 
